### PR TITLE
(WIP) Fixes in scripts

### DIFF
--- a/scripts/program_transformation.sh
+++ b/scripts/program_transformation.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-$PROJECT_DIR=$1
-$PROJECT_NAME=$2
+PROJECT_DIR=$1
+PROJECT_NAME=$2
+SUFFIX="_decomposed_tests"
 
-python3 src/preprocessing/refactor_methods.py $PROJECT_DIR $PROJECT_NAME
-python3 src/preprocessing/refactor_constructors.py $PROJECT_DIR $PROJECT_NAME
+python3 src/preprocessing/refactor_methods.py $PROJECT_DIR $PROJECT_NAME $SUFFIX
+python3 src/preprocessing/refactor_constructors.py $PROJECT_DIR $PROJECT_NAME $SUFFIX

--- a/src/preprocessing/refactor_constructors.py
+++ b/src/preprocessing/refactor_constructors.py
@@ -3,6 +3,7 @@ import os
 
 projects_dir = sys.argv[1]
 project = sys.argv[2]
+suffix = sys.argv[3]
 os.system(f'rm -rf java_projects/preprocessed_1/{project}')
 temp_project_path = f'java_projects/preprocessed_1/'
 os.makedirs(temp_project_path, exist_ok=True)
@@ -49,7 +50,7 @@ def get_args(line):
 
 def get_overloaded_constructors():
     constructors_lines = []
-    with open(f'data/query_outputs/{project}/{project}_all_constructors.txt', 'r') as f:
+    with open(f'data/query_outputs{suffix}/{project}/{project}_all_constructors.txt', 'r') as f:
         constructors_lines = f.readlines()
 
     constructors_lines = [x for x in constructors_lines if x.split('|')[7].strip() in ['super(...)', 'this(...)']]
@@ -151,7 +152,7 @@ def get_overloaded_constructors():
 
 def get_constructor_call_sites():
     constructor_call_graph_lines = []
-    with open(f'data/query_outputs/{project}/{project}_constructor_call_graph.txt', 'r') as f:
+    with open(f'data/query_outputs{suffix}/{project}/{project}_constructor_call_graph.txt', 'r') as f:
         constructor_call_graph_lines = f.readlines()
 
     constructor_call_sites = {}

--- a/src/preprocessing/refactor_methods.py
+++ b/src/preprocessing/refactor_methods.py
@@ -4,13 +4,14 @@ import sys
 
 projects_dir = sys.argv[1]
 project = sys.argv[2]
+suffix = sys.argv[3]
 os.system(f'rm -rf java_projects/preprocessed_0/{project}')
 temp_project_path = f'java_projects/preprocessed_0/'
 os.makedirs(temp_project_path, exist_ok=True)
 os.system(f'cp -r {projects_dir}/{project} {temp_project_path}')
 
 def get_overloaded_methods():
-    methods_query_out = f'data/query_outputs/{project}/{project}_all_methods.txt'
+    methods_query_out = f'data/query_outputs{suffix}/{project}/{project}_all_methods.txt'
     methods_lines = []
     with open(methods_query_out, 'r') as f:
         methods_lines = f.readlines()
@@ -106,7 +107,7 @@ def get_overloaded_methods():
 
 
 def get_overloaded_method_call_sites(overloaded_methods, all_methods):
-    call_graph_query_out = f'data/query_outputs/{project}/{project}_method_call_graph.txt'
+    call_graph_query_out = f'data/query_outputs{suffix}/{project}/{project}_method_call_graph.txt'
     call_graph_lines = []
     with open(call_graph_query_out, 'r') as f:
         call_graph_lines = f.readlines()
@@ -334,7 +335,7 @@ def rewrite_overloaded_method_calls(overloaded_method_locations):
 
 
 def rewrite_overridden_methods(overloaded_methods):
-    overridden_methods_query_out = f'data/query_outputs/{project}/{project}_overridden_methods.txt'
+    overridden_methods_query_out = f'data/query_outputs{suffix}/{project}/{project}_overridden_methods.txt'
     overridden_methods_lines = []
     with open(overridden_methods_query_out, 'r') as f:
         overridden_methods_lines = f.readlines()


### PR DESCRIPTION
1. Fixed syntax errors in `program_transformation.sh`.
2. Provide a `suffix` argument (similar to other scripts in the project) to `refactor_methods.py` and `refactor_constructors.py`.

> [!NOTE]
> This is not ready to merge. More fixes are being made.